### PR TITLE
Add interactive runtime for HyperCard demo

### DIFF
--- a/card-view.html
+++ b/card-view.html
@@ -37,15 +37,15 @@
 <section class="hc-content">
 
 <div class="hc-card" role="region" aria-label="Card Canvas">
-  <div class="hc-row" style="justify-content:space-between">
-    <button class="hc-button" data-nav="prev">Prev</button>
-    <div class="badge">Card 1 of 3 · Background: Main</div>
-    <button class="hc-button" data-nav="next">Next</button>
+    <div class="hc-row" style="justify-content:space-between">
+      <button class="hc-button" data-nav="prev">Prev</button>
+      <div class="badge" data-role="card-badge">Card 1 of 3 · Background: Main</div>
+      <button class="hc-button" data-nav="next">Next</button>
   </div>
   <div class="hc-row" style="margin-top:12px">
     <div class="hc-col" style="flex:2">
       <label class="hc-label" for="title-field">Field “Title”</label>
-      <div id="title-field" class="hc-field" contenteditable="true" role="textbox" aria-multiline="true">Welcome to HyperCard</div>
+      <div id="title-field" class="hc-field" contenteditable="true" role="textbox" aria-multiline="true" data-field="Title" tabindex="0">Welcome to HyperCard</div>
     </div>
     <div class="hc-col" style="flex:1">
       <label class="hc-label">Buttons</label>
@@ -58,16 +58,13 @@
   </div>
   <div class="hc-col" style="margin-top:12px">
     <label class="hc-label" for="body-field">Field “Body”</label>
-    <div id="body-field" class="hc-field" contenteditable="true" role="textbox" aria-multiline="true" style="min-height:220px">This is editable card text.</div>
+    <div id="body-field" class="hc-field" contenteditable="true" role="textbox" aria-multiline="true" style="min-height:220px" data-field="Body" tabindex="0">This is editable card text.</div>
   </div>
 </div>
 
 <section class="panel" style="margin-top:16px">
   <h3>Event stream (example)</h3>
-  <div class="kv">
-    <div>mouseDown</div><div><small class="meta">sent to topmost part under pointer</small></div>
-    <div>mouseUp</div><div><small class="meta">if pointer still within same part</small></div>
-    <div>openCard / closeCard</div><div><small class="meta">on card navigation</small></div>
+  <div class="kv" data-role="event-stream">
   </div>
 </section>
 

--- a/inspectors.html
+++ b/inspectors.html
@@ -41,11 +41,7 @@
     <h3>Card Inspector</h3>
     <table class="prop-table">
       <thead><tr><th>Property</th><th>Value</th></tr></thead>
-      <tbody>
-        <tr><td>id</td><td>2590</td></tr>
-        <tr><td>name</td><td>Card 1</td></tr>
-        <tr><td>visible</td><td>true</td></tr>
-        <tr><td>rect</td><td>0,0,740,460</td></tr>
+      <tbody data-inspector="card">
       </tbody>
     </table>
   </section>
@@ -53,11 +49,7 @@
     <h3>Field Inspector</h3>
     <table class="prop-table">
       <thead><tr><th>Property</th><th>Value</th></tr></thead>
-      <tbody>
-        <tr><td>name</td><td>Title</td></tr>
-        <tr><td>textFont</td><td>Geneva</td></tr>
-        <tr><td>textSize</td><td>12</td></tr>
-        <tr><td>lockText</td><td>false</td></tr>
+      <tbody data-inspector="field">
       </tbody>
     </table>
   </section>
@@ -65,10 +57,7 @@
     <h3>Stack Inspector</h3>
     <table class="prop-table">
       <thead><tr><th>Property</th><th>Value</th></tr></thead>
-      <tbody>
-        <tr><td>name</td><td>My Stack</td></tr>
-        <tr><td>cantModify</td><td>false</td></tr>
-        <tr><td>reportTemplates</td><td>Default Report</td></tr>
+      <tbody data-inspector="stack">
       </tbody>
     </table>
   </section>

--- a/main.js
+++ b/main.js
@@ -1,46 +1,766 @@
+class HyperCardRuntime extends EventTarget {
+  constructor() {
+    super();
+    this.stack = this.#createDefaultStack();
+    this.currentCardIndex = 0;
+    this.currentFieldName = this.stack.cards[0]?.fields[0]?.name ?? null;
+    this.recentCards = [];
+    this.messageLog = [];
+    this.variables = { it: '', result: '' };
+    this.commandHistory = [];
+    this.historyIndex = null;
+    this.messageBoxElements = { input: null, output: null };
+    this.#loadState();
+  }
 
-(function() {
-  const tools = document.querySelectorAll('.tool');
-  tools.forEach(btn => btn.addEventListener('click', () => {
-    tools.forEach(b => b.classList.remove('selected'));
-    btn.classList.add('selected');
-  }));
-  document.querySelectorAll('[data-action="toggle-message-box"]').forEach(a => {
-    a.addEventListener('click', (e) => {
-      e.preventDefault();
-      const mb = document.querySelector('.hc-message-box');
-      if (!mb) return;
-      mb.hidden = !mb.hidden;
-      document.getElementById('mb-input')?.focus();
-    });
-  });
-  document.querySelectorAll('[data-action="toggle-tools"]').forEach(a => {
-    a.addEventListener('click', (e) => {
-      e.preventDefault();
-      const toolsPane = document.querySelector('.hc-tools');
-      toolsPane.style.display = (toolsPane.style.display === 'none') ? 'block' : 'none';
-      document.querySelector('.hc-main').style.gridTemplateColumns = (toolsPane.style.display === 'none') ? '0 1fr' : '160px 1fr';
-    });
-  });
-  const mbInput = document.getElementById('mb-input');
-  const mbOutput = document.getElementById('mb-output');
-  if (mbInput && mbOutput) {
-    mbInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        // A tiny demo interpreter: echoes the line and fakes a result value.
-        const line = mbInput.value.trim();
-        if (!line) return;
-        if (/^beep/i.test(line)) {
-          mbOutput.value = '🔔 (beep)';
-        } else if (/^go\s+next/i.test(line)) {
-          mbOutput.value = '→ would go to next card';
-        } else if (/^answer/i.test(line)) {
-          mbOutput.value = 'would display an answer dialog';
-        } else {
-          mbOutput.value = 'sent line: ' + line;
+  initialize() {
+    this.#bindCommonUI();
+    this.#bindMessageBox();
+    this.#bindCardView();
+    this.#bindInspectors();
+    this.#bindScriptEditor();
+    this.#bindPreferences();
+    if (this.currentCard) {
+      this.#recordMessage('openCard', `card "${this.currentCard.name}"`);
+    }
+    this.#renderAll();
+  }
+
+  get currentCard() {
+    return this.stack.cards[this.currentCardIndex];
+  }
+
+  #createDefaultStack() {
+    return {
+      name: 'Demo HyperCard Stack',
+      cantModify: false,
+      userLevel: 5,
+      scriptTextFont: 'Monaco',
+      scriptTextSize: 12,
+      reportTemplates: ['Default Report', 'Mailing Labels'],
+      backgrounds: [
+        { id: 1, name: 'Main', rect: [0, 0, 740, 460] }
+      ],
+      cards: [
+        {
+          id: 2590,
+          name: 'Welcome',
+          backgroundId: 1,
+          rect: [0, 0, 740, 460],
+          fields: [
+            { id: 3000, name: 'Title', text: 'Welcome to HyperCard', textFont: 'Geneva', textSize: 12, lockText: false },
+            { id: 3001, name: 'Body', text: 'This stack demonstrates a tiny HyperCard-inspired runtime. Use the message box to try commands such as “go next” or “put \'Hello\' into field \'Body\'”.', textFont: 'Geneva', textSize: 12, lockText: false }
+          ],
+          buttons: [
+            {
+              id: 4000,
+              name: 'Show Tips',
+              script: 'on mouseUp\n  answer "HyperCard makes the Macintosh talk."\nend mouseUp'
+            }
+          ]
+        },
+        {
+          id: 2591,
+          name: 'Cards',
+          backgroundId: 1,
+          rect: [0, 0, 740, 460],
+          fields: [
+            { id: 3002, name: 'Title', text: 'Cards & Backgrounds', textFont: 'Geneva', textSize: 12, lockText: false },
+            { id: 3003, name: 'Body', text: 'Every card shares the background layer, but its own fields can vary. Use Prev/Next to travel, or try “go card 3”.', textFont: 'Geneva', textSize: 12, lockText: false }
+          ],
+          buttons: [
+            {
+              id: 4001,
+              name: 'Mark Card',
+              script: 'on mouseUp\n  put "marked" into card field "Body"\nend mouseUp'
+            }
+          ]
+        },
+        {
+          id: 2592,
+          name: 'Scripting',
+          backgroundId: 1,
+          rect: [0, 0, 740, 460],
+          fields: [
+            { id: 3004, name: 'Title', text: 'Scripting', textFont: 'Geneva', textSize: 12, lockText: false },
+            { id: 3005, name: 'Body', text: 'Commands update the message log and variable watcher. “beep”, “answer ...”, “put field \'Title\' into field \'Body\'” and more are recognised.', textFont: 'Geneva', textSize: 12, lockText: false }
+          ],
+          buttons: [
+            {
+              id: 4002,
+              name: 'About',
+              script: 'on mouseUp\n  answer "HyperTalk lives!"\nend mouseUp'
+            }
+          ]
         }
-        mbInput.value = '';
+      ]
+    };
+  }
+
+  #loadState() {
+    try {
+      const raw = window.localStorage?.getItem('hypercard-demo-state');
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed.cards)) {
+        parsed.cards.forEach(savedCard => {
+          const card = this.stack.cards.find(c => c.id === savedCard.id);
+          if (!card) return;
+          if (typeof savedCard.name === 'string') {
+            card.name = savedCard.name;
+          }
+          if (Array.isArray(savedCard.fields)) {
+            savedCard.fields.forEach(savedField => {
+              const field = card.fields.find(f => f.id === savedField.id);
+              if (field && typeof savedField.text === 'string') {
+                field.text = savedField.text;
+              }
+            });
+          }
+        });
+      }
+      if (typeof parsed.userLevel === 'number') {
+        this.stack.userLevel = parsed.userLevel;
+      }
+      if (typeof parsed.scriptTextFont === 'string') {
+        this.stack.scriptTextFont = parsed.scriptTextFont;
+      }
+      if (typeof parsed.scriptTextSize === 'number') {
+        this.stack.scriptTextSize = parsed.scriptTextSize;
+      }
+      if (typeof parsed.currentCardIndex === 'number') {
+        this.currentCardIndex = Math.max(0, Math.min(parsed.currentCardIndex, this.stack.cards.length - 1));
+      }
+      if (typeof parsed.currentFieldName === 'string') {
+        this.currentFieldName = parsed.currentFieldName;
+      }
+    } catch (error) {
+      console.warn('Unable to load saved HyperCard state', error);
+    }
+  }
+
+  #saveState() {
+    try {
+      const snapshot = {
+        userLevel: this.stack.userLevel,
+        scriptTextFont: this.stack.scriptTextFont,
+        scriptTextSize: this.stack.scriptTextSize,
+        currentCardIndex: this.currentCardIndex,
+        currentFieldName: this.currentFieldName,
+        cards: this.stack.cards.map(card => ({
+          id: card.id,
+          name: card.name,
+          fields: card.fields.map(field => ({ id: field.id, text: field.text }))
+        }))
+      };
+      window.localStorage?.setItem('hypercard-demo-state', JSON.stringify(snapshot));
+    } catch (error) {
+      console.warn('Unable to save HyperCard state', error);
+    }
+  }
+
+  #bindCommonUI() {
+    const tools = document.querySelectorAll('.tool');
+    if (tools.length) {
+      tools.forEach(btn => btn.addEventListener('click', () => {
+        tools.forEach(b => b.classList.remove('selected'));
+        btn.classList.add('selected');
+      }));
+    }
+
+    document.querySelectorAll('[data-action="toggle-message-box"]').forEach(el => {
+      el.addEventListener('click', event => {
+        event.preventDefault();
+        this.#toggleMessageBox();
+      });
+    });
+
+    document.querySelectorAll('[data-action="toggle-tools"]').forEach(el => {
+      el.addEventListener('click', event => {
+        event.preventDefault();
+        const toolsPane = document.querySelector('.hc-tools');
+        if (!toolsPane) return;
+        const willHide = toolsPane.style.display !== 'none';
+        toolsPane.style.display = willHide ? 'none' : 'block';
+        const main = document.querySelector('.hc-main');
+        if (main) {
+          main.style.gridTemplateColumns = willHide ? '0 1fr' : '160px 1fr';
+        }
+      });
+    });
+
+    document.addEventListener('keydown', event => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'm') {
+        event.preventDefault();
+        this.#toggleMessageBox();
       }
     });
   }
-})();
+
+  #toggleMessageBox() {
+    const messageBox = document.querySelector('.hc-message-box');
+    if (!messageBox) return;
+    messageBox.hidden = !messageBox.hidden;
+    if (!messageBox.hidden) {
+      this.messageBoxElements.input?.focus();
+    }
+  }
+
+  #bindMessageBox() {
+    const input = document.getElementById('mb-input');
+    const output = document.getElementById('mb-output');
+    if (!input || !output) return;
+
+    this.messageBoxElements = { input, output };
+
+    input.addEventListener('keydown', event => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        const line = input.value.trim();
+        if (!line) return;
+        this.commandHistory.push(line);
+        this.historyIndex = null;
+        const response = this.#executeCommand(line);
+        this.#setMessageBoxOutput(response);
+        input.value = '';
+        this.#saveState();
+      } else if (event.key === 'ArrowUp') {
+        if (!this.commandHistory.length) return;
+        event.preventDefault();
+        if (this.historyIndex === null) {
+          this.historyIndex = this.commandHistory.length - 1;
+        } else if (this.historyIndex > 0) {
+          this.historyIndex -= 1;
+        }
+        input.value = this.commandHistory[this.historyIndex];
+      } else if (event.key === 'ArrowDown') {
+        if (this.historyIndex === null) return;
+        event.preventDefault();
+        if (this.historyIndex < this.commandHistory.length - 1) {
+          this.historyIndex += 1;
+          input.value = this.commandHistory[this.historyIndex];
+        } else {
+          this.historyIndex = null;
+          input.value = '';
+        }
+      }
+    });
+  }
+
+  #executeCommand(line) {
+    this.#recordMessage('command', line);
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return '';
+    }
+    const lower = trimmed.toLowerCase();
+
+    if (lower === 'beep') {
+      this.variables.it = '';
+      this.variables.result = '';
+      this.#updateVariableWatcher();
+      return '🔔 (beep)';
+    }
+
+    if (lower.startsWith('go ')) {
+      const handled = this.#handleGoCommand(trimmed);
+      this.#updateVariableWatcher();
+      return handled ?? `Unknown navigation: ${trimmed}`;
+    }
+
+    const putMatch = trimmed.match(/^put\s+(.+?)\s+into\s+card\s+field\s+"([^"]+)"$/i) || trimmed.match(/^put\s+(.+?)\s+into\s+field\s+"([^"]+)"$/i);
+    if (putMatch) {
+      const value = this.#evaluateExpression(putMatch[1]);
+      const fieldName = putMatch[2];
+      const success = this.#setFieldText(fieldName, value, { log: true });
+      if (!success) {
+        this.variables.result = `Can't find field "${fieldName}"`;
+        this.#updateVariableWatcher();
+        return this.variables.result;
+      }
+      this.variables.it = value;
+      this.variables.result = '';
+      this.#renderCardFields();
+      this.#updateInspectors();
+      this.#updateVariableWatcher();
+      this.#saveState();
+      return value;
+    }
+
+    const getFieldMatch = trimmed.match(/^get\s+card\s+field\s+"([^"]+)"$/i) || trimmed.match(/^get\s+field\s+"([^"]+)"$/i);
+    if (getFieldMatch) {
+      const fieldName = getFieldMatch[1];
+      const fieldText = this.#getFieldText(fieldName);
+      this.variables.it = fieldText;
+      this.variables.result = '';
+      this.#updateVariableWatcher();
+      return fieldText;
+    }
+
+    const answerMatch = trimmed.match(/^answer\s+(.+)/i);
+    if (answerMatch) {
+      const message = this.#evaluateExpression(answerMatch[1]);
+      this.variables.it = 'OK';
+      this.variables.result = '';
+      this.#updateVariableWatcher();
+      return `answer "${message}" (simulated)`;
+    }
+
+    const findMatch = trimmed.match(/^find\s+(.+)/i);
+    if (findMatch) {
+      const query = this.#evaluateExpression(findMatch[1]);
+      const outcome = this.#findAndGo(query);
+      this.#updateVariableWatcher();
+      return outcome ? `found "${query}"` : `Couldn't find "${query}"`;
+    }
+
+    this.variables.it = '';
+    this.variables.result = trimmed;
+    this.#updateVariableWatcher();
+    return `sent line: ${trimmed}`;
+  }
+
+  #handleGoCommand(command) {
+    const matchCardNumber = command.match(/^go\s+card\s+(\d+)/i);
+    if (matchCardNumber) {
+      const number = Number(matchCardNumber[1]);
+      if (!Number.isNaN(number) && number >= 1 && number <= this.stack.cards.length) {
+        this.#goToCard(number - 1, 'card number');
+        return `→ went to card ${number}`;
+      }
+      this.variables.result = `Can't go to card ${matchCardNumber[1]}`;
+      return this.variables.result;
+    }
+
+    const matchCardName = command.match(/^go\s+card\s+"([^"]+)"/i);
+    if (matchCardName) {
+      const name = matchCardName[1].toLowerCase();
+      const index = this.stack.cards.findIndex(card => card.name.toLowerCase() === name);
+      if (index >= 0) {
+        this.#goToCard(index, 'card name');
+        return `→ went to card "${this.stack.cards[index].name}"`;
+      }
+      this.variables.result = `Can't find that card`;
+      return this.variables.result;
+    }
+
+    if (/go\s+next/i.test(command)) {
+      this.#goToCard((this.currentCardIndex + 1) % this.stack.cards.length, 'next');
+      return '→ went to next card';
+    }
+
+    if (/go\s+(previous|prev)/i.test(command)) {
+      const nextIndex = (this.currentCardIndex - 1 + this.stack.cards.length) % this.stack.cards.length;
+      this.#goToCard(nextIndex, 'previous');
+      return '→ went to previous card';
+    }
+
+    if (/go\s+first/i.test(command)) {
+      this.#goToCard(0, 'first');
+      return '→ went to first card';
+    }
+
+    if (/go\s+last/i.test(command)) {
+      this.#goToCard(this.stack.cards.length - 1, 'last');
+      return '→ went to last card';
+    }
+
+    if (/go\s+recent/i.test(command)) {
+      const recent = this.recentCards.shift();
+      if (recent) {
+        const index = this.stack.cards.findIndex(card => card.id === recent);
+        if (index >= 0) {
+          this.#goToCard(index, 'recent');
+          return '→ went to recent card';
+        }
+      }
+      this.variables.result = 'no recent card';
+      return 'No recent card';
+    }
+
+    return null;
+  }
+
+  #evaluateExpression(expr) {
+    const trimmed = expr.trim();
+    const quoted = trimmed.match(/^"([\s\S]*)"$/);
+    if (quoted) {
+      return quoted[1];
+    }
+    const fieldExpr = trimmed.match(/^card\s+field\s+"([^"]+)"$/i) || trimmed.match(/^field\s+"([^"]+)"$/i);
+    if (fieldExpr) {
+      return this.#getFieldText(fieldExpr[1]);
+    }
+    if (/^the\s+name\s+of\s+this\s+card$/i.test(trimmed)) {
+      return this.currentCard?.name ?? '';
+    }
+    if (/^the\s+number\s+of\s+cards$/i.test(trimmed)) {
+      return String(this.stack.cards.length);
+    }
+    if (/^the\s+result$/i.test(trimmed)) {
+      return this.variables.result;
+    }
+    if (/^it$/i.test(trimmed)) {
+      return this.variables.it;
+    }
+    return trimmed;
+  }
+
+  #bindCardView() {
+    const cardPane = document.querySelector('.hc-card');
+    if (!cardPane) return;
+
+    document.querySelectorAll('[data-nav]').forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        const dir = button.getAttribute('data-nav');
+        if (dir === 'next') {
+          this.#goToCard((this.currentCardIndex + 1) % this.stack.cards.length, 'next');
+        } else if (dir === 'prev' || dir === 'previous') {
+          const nextIndex = (this.currentCardIndex - 1 + this.stack.cards.length) % this.stack.cards.length;
+          this.#goToCard(nextIndex, 'previous');
+        }
+      });
+    });
+
+    document.querySelectorAll('[data-action="go-first"]').forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        this.#goToCard(0, 'first button');
+      });
+    });
+
+    document.querySelectorAll('[data-action="go-recent"]').forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        const recent = this.recentCards.shift();
+        if (recent) {
+          const index = this.stack.cards.findIndex(card => card.id === recent);
+          if (index >= 0) {
+            this.#goToCard(index, 'recent button');
+            return;
+          }
+        }
+        this.#setMessageBoxOutput('No recent card');
+      });
+    });
+
+    document.querySelectorAll('[data-action="find"]').forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        const query = window.prompt('Find text:');
+        if (!query) {
+          this.variables.result = 'cancel';
+          this.#updateVariableWatcher();
+          return;
+        }
+        const found = this.#findAndGo(query);
+        this.#setMessageBoxOutput(found ? `found "${query}"` : `Couldn't find "${query}"`);
+      });
+    });
+
+    const fieldElements = document.querySelectorAll('[data-field]');
+    fieldElements.forEach(element => {
+      element.addEventListener('focus', () => {
+        const fieldName = element.getAttribute('data-field');
+        if (!fieldName) return;
+        this.currentFieldName = fieldName;
+        this.#recordMessage('openField', `field "${fieldName}"`);
+        this.#updateInspectors();
+        this.#saveState();
+      });
+      element.addEventListener('blur', () => {
+        const fieldName = element.getAttribute('data-field');
+        if (!fieldName) return;
+        this.#recordMessage('closeField', `field "${fieldName}"`);
+        this.#updateInspectors();
+        this.#saveState();
+      });
+      element.addEventListener('input', () => {
+        const fieldName = element.getAttribute('data-field');
+        if (!fieldName) return;
+        this.#setFieldText(fieldName, element.textContent ?? '', { log: false, skipRender: true });
+        this.#updateInspectors();
+      });
+    });
+  }
+
+  #bindInspectors() {
+    const containers = document.querySelectorAll('[data-inspector]');
+    if (!containers.length) return;
+    this.#updateInspectors();
+  }
+
+  #bindScriptEditor() {
+    const scriptArea = document.querySelector('[data-role="script-source"]');
+    if (!scriptArea) return;
+    const button = this.currentCard?.buttons?.[0];
+    if (button) {
+      scriptArea.value = button.script;
+      scriptArea.dataset.buttonId = String(button.id);
+    }
+    this.#applyScriptEditorPreferences(scriptArea);
+    scriptArea.addEventListener('input', () => {
+      const id = Number(scriptArea.dataset.buttonId);
+      if (!id) return;
+      const card = this.currentCard;
+      const target = card?.buttons?.find(btn => btn.id === id);
+      if (!target) return;
+      target.script = scriptArea.value;
+      this.#recordMessage('scriptEdited', `button "${target.name}"`);
+      this.#saveState();
+    });
+  }
+
+  #bindPreferences() {
+    const levelSelect = document.querySelector('[data-pref="user-level"]');
+    if (levelSelect) {
+      levelSelect.value = String(this.stack.userLevel);
+      levelSelect.addEventListener('change', () => {
+        const value = Number(levelSelect.value);
+        if (!Number.isNaN(value) && value >= 1 && value <= 5) {
+          this.stack.userLevel = value;
+          this.#recordMessage('userLevelChanged', `userLevel = ${value}`);
+          this.#updateVariableWatcher();
+          this.#saveState();
+        }
+      });
+    }
+
+    const fontInput = document.querySelector('[data-pref="script-font"]');
+    if (fontInput) {
+      fontInput.value = this.stack.scriptTextFont;
+      fontInput.addEventListener('change', () => {
+        if (!fontInput.value.trim()) return;
+        this.stack.scriptTextFont = fontInput.value.trim();
+        this.#recordMessage('setProperty', `scriptTextFont = ${this.stack.scriptTextFont}`);
+        this.#applyScriptEditorPreferences();
+        this.#saveState();
+      });
+    }
+
+    const sizeInput = document.querySelector('[data-pref="script-size"]');
+    if (sizeInput) {
+      sizeInput.value = String(this.stack.scriptTextSize);
+      sizeInput.addEventListener('change', () => {
+        const value = Number(sizeInput.value);
+        if (!Number.isNaN(value) && value > 0) {
+          this.stack.scriptTextSize = value;
+          this.#recordMessage('setProperty', `scriptTextSize = ${value}`);
+          this.#applyScriptEditorPreferences();
+          this.#saveState();
+        }
+      });
+    }
+  }
+
+  #renderAll() {
+    this.#renderCardView();
+    this.#updateInspectors();
+    this.#updateMessageWatcher();
+    this.#updateVariableWatcher();
+  }
+
+  #renderCardView() {
+    const badge = document.querySelector('[data-role="card-badge"]');
+    const card = this.currentCard;
+    if (badge && card) {
+      const background = this.stack.backgrounds.find(bg => bg.id === card.backgroundId);
+      badge.textContent = `Card ${this.currentCardIndex + 1} of ${this.stack.cards.length} · Background: ${background?.name ?? '—'}`;
+    }
+    this.#renderCardFields();
+    this.#renderEventStream();
+  }
+
+  #renderCardFields() {
+    const card = this.currentCard;
+    if (!card) return;
+    document.querySelectorAll('[data-field]').forEach(element => {
+      const fieldName = element.getAttribute('data-field');
+      if (!fieldName) return;
+      const field = card.fields.find(f => f.name.toLowerCase() === fieldName.toLowerCase());
+      if (!field) {
+        element.textContent = '';
+        return;
+      }
+      if (document.activeElement !== element) {
+        element.textContent = field.text;
+      }
+    });
+  }
+
+  #renderEventStream() {
+    const container = document.querySelector('[data-role="event-stream"]');
+    if (!container) return;
+    container.innerHTML = '';
+    const recent = this.messageLog.slice(-6);
+    recent.forEach(entry => {
+      const nameCell = document.createElement('div');
+      nameCell.textContent = entry.name;
+      const detailCell = document.createElement('div');
+      const detail = entry.detail ? entry.detail : '\u00A0';
+      detailCell.innerHTML = `<small class="meta">${detail}</small>`;
+      container.append(nameCell, detailCell);
+    });
+  }
+
+  #updateInspectors() {
+    const card = this.currentCard;
+    if (!card) return;
+    this.#fillInspector('card', [
+      ['id', card.id],
+      ['name', card.name],
+      ['number', this.currentCardIndex + 1],
+      ['background', this.stack.backgrounds.find(bg => bg.id === card.backgroundId)?.name ?? ''],
+      ['rect', card.rect.join(',')],
+      ['visible', 'true']
+    ]);
+
+    const field = this.#getCurrentField();
+    if (field) {
+      this.#fillInspector('field', [
+        ['id', field.id],
+        ['name', field.name],
+        ['textFont', field.textFont ?? this.stack.scriptTextFont],
+        ['textSize', field.textSize ?? this.stack.scriptTextSize],
+        ['lockText', field.lockText ? 'true' : 'false'],
+        ['length', field.text.length]
+      ]);
+    }
+
+    this.#fillInspector('stack', [
+      ['name', this.stack.name],
+      ['userLevel', this.stack.userLevel],
+      ['cantModify', this.stack.cantModify ? 'true' : 'false'],
+      ['cardCount', this.stack.cards.length],
+      ['reportTemplates', this.stack.reportTemplates.join(', ')]
+    ]);
+  }
+
+  #fillInspector(type, rows) {
+    const container = document.querySelector(`[data-inspector="${type}"]`);
+    if (!container) return;
+    container.innerHTML = '';
+    rows.forEach(([prop, value]) => {
+      const row = document.createElement('tr');
+      const propCell = document.createElement('td');
+      propCell.textContent = prop;
+      const valueCell = document.createElement('td');
+      valueCell.textContent = String(value);
+      row.append(propCell, valueCell);
+      container.append(row);
+    });
+  }
+
+  #updateMessageWatcher() {
+    const watcher = document.querySelector('[data-role="message-watcher"]');
+    if (!watcher) return;
+    const lines = this.messageLog.slice(-12).map(entry => entry.detail ? `${entry.name} — ${entry.detail}` : entry.name);
+    watcher.textContent = lines.join('\n');
+  }
+
+  #updateVariableWatcher() {
+    const watcher = document.querySelector('[data-role="variable-watcher"]');
+    if (!watcher) return;
+    const lines = [
+      `userLevel = ${this.stack.userLevel}`,
+      `it = "${this.variables.it}"`,
+      `the result = "${this.variables.result}"`,
+      `currentCard = ${this.currentCardIndex + 1}`
+    ];
+    if (this.recentCards.length) {
+      lines.push(`recentCards = ${this.recentCards.join(', ')}`);
+    }
+    watcher.textContent = lines.join('\n');
+  }
+
+  #applyScriptEditorPreferences(scriptArea = document.querySelector('[data-role="script-source"]')) {
+    if (!scriptArea) return;
+    scriptArea.style.fontFamily = this.stack.scriptTextFont;
+    scriptArea.style.fontSize = `${this.stack.scriptTextSize}px`;
+  }
+
+  #recordMessage(name, detail = '') {
+    this.messageLog.push({ name, detail });
+    if (this.messageLog.length > 40) {
+      this.messageLog.shift();
+    }
+    this.#renderEventStream();
+    this.#updateMessageWatcher();
+  }
+
+  #setFieldText(fieldName, text, options = {}) {
+    const card = this.currentCard;
+    if (!card) return false;
+    const field = card.fields.find(f => f.name.toLowerCase() === fieldName.toLowerCase());
+    if (!field) return false;
+    field.text = text;
+    this.currentFieldName = field.name;
+    if (!options.skipRender) {
+      this.#renderCardFields();
+    }
+    if (options.log) {
+      this.#recordMessage('setField', `field "${field.name}"`);
+    }
+    return true;
+  }
+
+  #getFieldText(fieldName) {
+    const card = this.currentCard;
+    if (!card) return '';
+    const field = card.fields.find(f => f.name.toLowerCase() === fieldName.toLowerCase());
+    return field ? field.text : '';
+  }
+
+  #getCurrentField() {
+    const name = this.currentFieldName;
+    if (!name) return this.currentCard?.fields?.[0] ?? null;
+    return this.currentCard?.fields?.find(f => f.name === name) ?? this.currentCard?.fields?.[0] ?? null;
+  }
+
+  #goToCard(index, reason) {
+    if (index === this.currentCardIndex) return;
+    const oldCard = this.currentCard;
+    if (oldCard) {
+      this.#recordMessage('closeCard', `card "${oldCard.name}"`);
+      this.recentCards = [oldCard.id, ...this.recentCards].slice(0, 20);
+    }
+    this.currentCardIndex = index;
+    const card = this.currentCard;
+    if (card) {
+      this.#recordMessage('openCard', `card "${card.name}"`);
+    }
+    this.currentFieldName = card?.fields?.[0]?.name ?? null;
+    this.variables.it = '';
+    this.variables.result = '';
+    this.#renderCardView();
+    this.#updateInspectors();
+    this.#updateVariableWatcher();
+    this.#saveState();
+  }
+
+  #findAndGo(query) {
+    const lower = query.toLowerCase();
+    const index = this.stack.cards.findIndex(card => card.fields.some(field => field.text.toLowerCase().includes(lower)));
+    if (index >= 0) {
+      this.variables.it = query;
+      this.variables.result = '';
+      this.#goToCard(index, 'find');
+      this.#recordMessage('find', `"${query}"`);
+      return true;
+    }
+    this.variables.result = 'not found';
+    this.#updateVariableWatcher();
+    return false;
+  }
+
+  #setMessageBoxOutput(text) {
+    if (this.messageBoxElements.output) {
+      this.messageBoxElements.output.value = text;
+    }
+  }
+}
+
+const runtime = new HyperCardRuntime();
+runtime.initialize();
+window.hypercard = runtime;

--- a/preferences.html
+++ b/preferences.html
@@ -40,21 +40,21 @@
   <h3>Preferences</h3>
   <div class="hc-grid">
     <div class="hc-col">
-      <label class="hc-label">User Level</label>
-      <select class="hc-field">
-        <option>1 — Browsing</option>
-        <option>2 — Typing</option>
-        <option>3 — Painting</option>
-        <option>4 — Authoring</option>
-        <option selected>5 — Scripting</option>
+      <label class="hc-label" for="pref-user-level">User Level</label>
+      <select id="pref-user-level" class="hc-field" data-pref="user-level">
+        <option value="1">1 — Browsing</option>
+        <option value="2">2 — Typing</option>
+        <option value="3">3 — Painting</option>
+        <option value="4">4 — Authoring</option>
+        <option value="5">5 — Scripting</option>
       </select>
       <small class="meta">Set <code class="k">userLevel</code> (1–5) in your runtime.</small>
     </div>
     <div class="hc-col">
-      <label class="hc-label">Script Editor Font</label>
-      <input class="hc-field" placeholder="scriptTextFont (e.g., Monaco)">
-      <label class="hc-label">Script Editor Size</label>
-      <input class="hc-field" placeholder="scriptTextSize (e.g., 9)">
+      <label class="hc-label" for="pref-script-font">Script Editor Font</label>
+      <input id="pref-script-font" class="hc-field" data-pref="script-font" placeholder="scriptTextFont (e.g., Monaco)">
+      <label class="hc-label" for="pref-script-size">Script Editor Size</label>
+      <input id="pref-script-size" class="hc-field" data-pref="script-size" placeholder="scriptTextSize (e.g., 9)" inputmode="numeric">
     </div>
   </div>
 </section>

--- a/script-editor.html
+++ b/script-editor.html
@@ -45,20 +45,16 @@
       <button class="hc-button">Set Breakpoint</button>
       <button class="hc-button">Save</button>
     </div>
-    <textarea aria-label="Script" class="hc-field" style="min-height:280px; font-family: var(--mono); white-space: pre; overflow:auto;">on mouseUp
+    <textarea aria-label="Script" class="hc-field" data-role="script-source" style="min-height:280px; font-family: var(--mono); white-space: pre; overflow:auto;">on mouseUp
   answer &quot;You clicked&quot;
 end mouseUp</textarea>
     <small class="meta">Use global properties like <code class="k">scriptTextFont</code> and <code class="k">scriptTextSize</code> to affect the editor’s appearance via your runtime.</small>
   </section>
   <section class="panel">
     <h3>Message Watcher</h3>
-    <div class="hc-field" style="min-height:120px; font-family: var(--mono); overflow:auto;">openCard
-mouseEnter button &quot;Home&quot;
-mouseDown
-mouseUp</div>
+    <div class="hc-field" data-role="message-watcher" style="min-height:120px; font-family: var(--mono); overflow:auto; white-space:pre-wrap;">openCard</div>
     <h3 style="margin-top:12px">Variable Watcher</h3>
-    <div class="hc-field" style="min-height:120px; font-family: var(--mono); overflow:auto;">userLevel = 5
-it = &quot;OK&quot;</div>
+    <div class="hc-field" data-role="variable-watcher" style="min-height:120px; font-family: var(--mono); overflow:auto; white-space:pre-wrap;">userLevel = 5</div>
   </section>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,10 @@ body {
 .mb-form { display: grid; grid-template-columns: 72px 1fr; gap: 12px; align-items: center; }
 #mb-input { padding: 10px; border-radius: 6px; border: 1px solid var(--border); font-family: var(--mono); }
 #mb-output { display: block; grid-column: 1 / -1; padding: 6px 0; color: var(--muted); font-family: var(--mono); }
+[data-role="message-watcher"],
+[data-role="variable-watcher"] { font-family: var(--mono); white-space: pre-wrap; }
+[data-role="event-stream"] { min-height: 72px; }
+[data-role="event-stream"] > div { padding: 2px 0; }
 /* Inspector tables */
 .prop-table { width: 100%; border-collapse: collapse; }
 .prop-table th, .prop-table td { border: 1px solid var(--border); padding: 8px; font-size: 14px; }


### PR DESCRIPTION
## Summary
- implement a runtime that models a demo stack with card navigation, message logging, and inspector updates
- extend the message box to interpret common HyperTalk commands and persist stack/user preference changes
- wire the card view, script editor, inspectors, and preferences markup so the runtime can drive their UI

## Testing
- not run (HTML/JS only)


------
https://chatgpt.com/codex/tasks/task_b_68d6e887d0e083328af139849e8e0861